### PR TITLE
Synpop xml writers

### DIFF
--- a/matsim/writers.py
+++ b/matsim/writers.py
@@ -18,7 +18,7 @@ class XmlWriter:
         self.writer.write(bytes(content, "utf-8"))
 
     def _require_scope(self, scope):
-        if scope == None and not self.scope is None:
+        if not scope == None and not self.scope is None:
             raise RuntimeError("Execpted initial scope")
 
         if not self.scope == scope:
@@ -259,41 +259,3 @@ class FacilitiesWriter(XmlWriter):
         self._require_scope(self.FACILITY_SCOPE)
         self._write_line('<activity type="%s" />' % purpose)
 
-
-class backlog_iterator:
-    def __init__(self, iterable, backlog = 1):
-        self.iterable = iterable
-        self.forward_log = []
-        self.backward_log = [None] * (backlog + 1)
-
-    def next(self):
-        if len(self.forward_log) > 0:
-            self.backward_log.append(self.forward_log[0])
-            del self.forward_log[0]
-        else:
-            self.backward_log.append(next(self.iterable))
-
-        del self.backward_log[0]
-        return self.backward_log[-1]
-
-    def previous(self):
-        self.forward_log.insert(0, self.backward_log[-1])
-        del self.backward_log[-1]
-        self.backward_log.insert(0, None)
-        return self.backward_log[-1]
-
-    def current(self):
-        return self.backlog[-1]
-
-    def has_previous(self):
-        return len(self.backward_log) > 1
-
-    def has_next(self):
-        if len(self.forward_log) > 0:
-            return True
-
-        try:
-            self.forward_log.append(next(self.iterable))
-            return True
-        except StopIteration:
-            return False

--- a/matsim/writers.py
+++ b/matsim/writers.py
@@ -24,16 +24,16 @@ class XmlWriter:
         if not self.scope == scope:
             raise RuntimeError("Expected different scope")
 
-    @static
-    def yes_no(self, value):
+    @staticmethod
+    def yes_no(value):
         return "yes" if value else "no"
 
-    @static
+    @staticmethod
     def true_false(self, value):
         return "true" if value else "false"
 
-    @static
-    def time(self, time):
+    @staticmethod
+    def time(time):
         if np.isnan(time):
             return None
 
@@ -43,13 +43,12 @@ class XmlWriter:
         seconds = (time % 60)
         return "%02d:%02d:%02d" % (hours, minutes, seconds)
 
-    @static
-    def location(self, x, y, facility_id=None):
+    @staticmethod
+    def location(x, y, facility_id=None):
         return x, y, None if facility_id is None else facility_id
 
-    @static
-    def _write_preface_attributes(self, attributes):
-        if len(attributes) > 0:
+    def _write_preface_attributes(self, attributes=None):
+        if attributes:
             self._write_line('<attributes>')
             self.indent += 1
 
@@ -70,14 +69,14 @@ class PopulationWriter(XmlWriter):
     def __init__(self, writer):
         XmlWriter.__init__(self, writer)
 
-    def start_population(self, attributes={}):
+    def start_population(self, attributes=None):
         self._require_scope(None)
         self._write_line('<?xml version="1.0" encoding="utf-8"?>')
         self._write_line('<!DOCTYPE population SYSTEM "http://www.matsim.org/files/dtd/population_v6.dtd">')
         self._write_line('<population>')
         self.scope = self.POPULATION_SCOPE
         self.indent += 1
-        _write_preface_attributes(self, attributes)
+        self._write_preface_attributes(attributes)
 
     def end_population(self):
         self._require_scope(self.POPULATION_SCOPE)
@@ -157,7 +156,7 @@ class HouseholdsWriter(XmlWriter):
     def __init__(self, writer):
         XmlWriter.__init__(self, writer)
 
-    def start_households(self, attributes={}):
+    def start_households(self, attributes=None):
         self._require_scope(None)
         self._write_line('<?xml version="1.0" encoding="utf-8"?>')
         self._write_line('<households xmlns="http://www.matsim.org/files/dtd" '
@@ -166,7 +165,7 @@ class HouseholdsWriter(XmlWriter):
                          'http://www.matsim.org/files/dtd/households_v1.0.xsd">')
         self.scope = self.HOUSEHOLDS_SCOPE
         self.indent += 1
-        _write_preface_attributes(self, attributes)
+        self._write_preface_attributes(attributes)
 
     def end_households(self):
         self._require_scope(self.HOUSEHOLDS_SCOPE)
@@ -225,7 +224,7 @@ class FacilitiesWriter(XmlWriter):
     def __init__(self, writer):
         XmlWriter.__init__(self, writer)
 
-    def start_facilities(self, attributes={}):
+    def start_facilities(self, attributes=None):
         self._require_scope(None)
         self._write_line('<?xml version="1.0" encoding="utf-8"?>')
         self._write_line('<!DOCTYPE facilities SYSTEM "http://www.matsim.org/files/dtd/facilities_v1.dtd">')
@@ -233,7 +232,7 @@ class FacilitiesWriter(XmlWriter):
         self.scope = self.FACILITIES_SCOPE
         self.indent += 1
 
-        _write_preface_attributes(self, attributes)
+        self._write_preface_attributes(attributes)
 
     def end_facilities(self):
         self._require_scope(self.FACILITIES_SCOPE)

--- a/matsim/writers.py
+++ b/matsim/writers.py
@@ -18,18 +18,21 @@ class XmlWriter:
         self.writer.write(bytes(content, "utf-8"))
 
     def _require_scope(self, scope):
-        if not scope == None and not self.scope is None:
-            raise RuntimeError("Execpted initial scope")
+        if not scope and self.scope is not None:
+            raise RuntimeError("Expected initial scope")
 
         if not self.scope == scope:
             raise RuntimeError("Expected different scope")
 
+    @static
     def yes_no(self, value):
         return "yes" if value else "no"
 
+    @static
     def true_false(self, value):
         return "true" if value else "false"
 
+    @static
     def time(self, time):
         if np.isnan(time):
             return None
@@ -40,20 +43,21 @@ class XmlWriter:
         seconds = (time % 60)
         return "%02d:%02d:%02d" % (hours, minutes, seconds)
 
-    def location(self, x, y, facility_id = None):
-        return (x, y, None if facility_id is None else facility_id)
+    @static
+    def location(self, x, y, facility_id=None):
+        return x, y, None if facility_id is None else facility_id
 
+    @static
+    def _write_preface_attributes(self, attributes):
+        if len(attributes) > 0:
+            self._write_line('<attributes>')
+            self.indent += 1
 
-def _write_preface_attributes(writer, attributes):
-    if len(attributes) > 0:
-        writer._write_line('<attributes>')
-        writer.indent += 1
+            for item in attributes.items():
+                self._write_line('<attribute name="%s" class="java.lang.String">%s</attribute>' % item)
 
-        for item in attributes.items():
-            writer._write_line('<attribute name="%s" class="java.lang.String">%s</attribute>' % item)
-
-        writer.indent -= 1
-        writer._write_line('</attributes>')
+            self.indent -= 1
+            self._write_line('</attributes>')
 
 
 class PopulationWriter(XmlWriter):
@@ -66,15 +70,13 @@ class PopulationWriter(XmlWriter):
     def __init__(self, writer):
         XmlWriter.__init__(self, writer)
 
-    def start_population(self, attributes = {}):
+    def start_population(self, attributes={}):
         self._require_scope(None)
         self._write_line('<?xml version="1.0" encoding="utf-8"?>')
         self._write_line('<!DOCTYPE population SYSTEM "http://www.matsim.org/files/dtd/population_v6.dtd">')
         self._write_line('<population>')
-
         self.scope = self.POPULATION_SCOPE
         self.indent += 1
-
         _write_preface_attributes(self, attributes)
 
     def end_population(self):
@@ -125,9 +127,8 @@ class PopulationWriter(XmlWriter):
         self.scope = self.PERSON_SCOPE
         self._write_line('</plan>')
 
-    def add_activity(self, type, location, start_time = None, end_time = None):
+    def add_activity(self, type, location, start_time=None, end_time=None):
         self._require_scope(self.PLAN_SCOPE)
-
         self._write_indent()
         self._write('<activity ')
         self._write('type="%s" ' % type)
@@ -139,7 +140,6 @@ class PopulationWriter(XmlWriter):
 
     def add_leg(self, mode, departure_time, travel_time):
         self._require_scope(self.PLAN_SCOPE)
-
         self._write_indent()
         self._write('<leg ')
         self._write('mode="%s" ' % mode)
@@ -157,14 +157,15 @@ class HouseholdsWriter(XmlWriter):
     def __init__(self, writer):
         XmlWriter.__init__(self, writer)
 
-    def start_households(self, attributes = {}):
+    def start_households(self, attributes={}):
         self._require_scope(None)
         self._write_line('<?xml version="1.0" encoding="utf-8"?>')
-        self._write_line('<households xmlns="http://www.matsim.org/files/dtd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/households_v1.0.xsd">')
-
+        self._write_line('<households xmlns="http://www.matsim.org/files/dtd" '
+                         'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+                         'xsi:schemaLocation="http://www.matsim.org/files/dtd '
+                         'http://www.matsim.org/files/dtd/households_v1.0.xsd">')
         self.scope = self.HOUSEHOLDS_SCOPE
         self.indent += 1
-
         _write_preface_attributes(self, attributes)
 
     def end_households(self):
@@ -206,7 +207,8 @@ class HouseholdsWriter(XmlWriter):
         self._require_scope(self.HOUSEHOLD_SCOPE)
         self._write_line('<members>')
         self.indent += 1
-        for person_id in person_ids: self._write_line('<personId refId="%s" />' % person_id)
+        for person_id in person_ids:
+            self._write_line('<personId refId="%s" />' % person_id)
         self.indent -= 1
         self._write_line('</members>')
 
@@ -223,12 +225,11 @@ class FacilitiesWriter(XmlWriter):
     def __init__(self, writer):
         XmlWriter.__init__(self, writer)
 
-    def start_facilities(self, attributes = {}):
+    def start_facilities(self, attributes={}):
         self._require_scope(None)
         self._write_line('<?xml version="1.0" encoding="utf-8"?>')
         self._write_line('<!DOCTYPE facilities SYSTEM "http://www.matsim.org/files/dtd/facilities_v1.dtd">')
         self._write_line('<facilities>')
-
         self.scope = self.FACILITIES_SCOPE
         self.indent += 1
 
@@ -245,7 +246,6 @@ class FacilitiesWriter(XmlWriter):
         self._write_line('<facility id="%s" x="%f" y="%f">' % (
             str(facility_id), x, y
         ))
-
         self.indent += 1
         self.scope = self.FACILITY_SCOPE
 

--- a/matsim/writers.py
+++ b/matsim/writers.py
@@ -1,0 +1,299 @@
+import numpy as np
+
+
+class XmlWriter:
+    def __init__(self, writer):
+        self.writer = writer
+        self.indent = 0
+        self.scope = None
+
+    def _write_line(self, content):
+        self._write_indent()
+        self._write(content + "\n")
+
+    def _write_indent(self):
+        self._write("  " * self.indent)
+
+    def _write(self, content):
+        self.writer.write(bytes(content, "utf-8"))
+
+    def _require_scope(self, scope):
+        if scope == None and not self.scope is None:
+            raise RuntimeError("Execpted initial scope")
+
+        if not self.scope == scope:
+            raise RuntimeError("Expected different scope")
+
+    def yes_no(self, value):
+        return "yes" if value else "no"
+
+    def true_false(self, value):
+        return "true" if value else "false"
+
+    def time(self, time):
+        if np.isnan(time):
+            return None
+
+        time = int(time)
+        hours = time // 3600
+        minutes = (time % 3600) // 60
+        seconds = (time % 60)
+        return "%02d:%02d:%02d" % (hours, minutes, seconds)
+
+    def location(self, x, y, facility_id = None):
+        return (x, y, None if facility_id is None else facility_id)
+
+
+def _write_preface_attributes(writer, attributes):
+    if len(attributes) > 0:
+        writer._write_line('<attributes>')
+        writer.indent += 1
+
+        for item in attributes.items():
+            writer._write_line('<attribute name="%s" class="java.lang.String">%s</attribute>' % item)
+
+        writer.indent -= 1
+        writer._write_line('</attributes>')
+
+
+class PopulationWriter(XmlWriter):
+    POPULATION_SCOPE = 0
+    FINISHED_SCOPE = 1
+    PERSON_SCOPE = 2
+    PLAN_SCOPE = 3
+    ATTRIBUTES_SCOPE = 4
+
+    def __init__(self, writer):
+        XmlWriter.__init__(self, writer)
+
+    def start_population(self, attributes = {}):
+        self._require_scope(None)
+        self._write_line('<?xml version="1.0" encoding="utf-8"?>')
+        self._write_line('<!DOCTYPE population SYSTEM "http://www.matsim.org/files/dtd/population_v6.dtd">')
+        self._write_line('<population>')
+
+        self.scope = self.POPULATION_SCOPE
+        self.indent += 1
+
+        _write_preface_attributes(self, attributes)
+
+    def end_population(self):
+        self._require_scope(self.POPULATION_SCOPE)
+        self.indent -= 1
+        self._write_line('</population>')
+        self.scope = self.FINISHED_SCOPE
+
+    def start_person(self, person_id):
+        self._require_scope(self.POPULATION_SCOPE)
+        self._write_line('<person id="%d">' % person_id)
+        self.scope = self.PERSON_SCOPE
+        self.indent += 1
+
+    def end_person(self):
+        self._require_scope(self.PERSON_SCOPE)
+        self.indent -= 1
+        self.scope = self.POPULATION_SCOPE
+        self._write_line('</person>')
+
+    def start_attributes(self):
+        self._require_scope(self.PERSON_SCOPE)
+        self._write_line('<attributes>')
+        self.indent += 1
+        self.scope = self.ATTRIBUTES_SCOPE
+
+    def end_attributes(self):
+        self._require_scope(self.ATTRIBUTES_SCOPE)
+        self.indent -= 1
+        self.scope = self.PERSON_SCOPE
+        self._write_line('</attributes>')
+
+    def add_attribute(self, name, type, value):
+        self._require_scope(self.ATTRIBUTES_SCOPE)
+        self._write_line('<attribute name="%s" class="%s">%s</attribute>' % (
+            name, type, value
+        ))
+
+    def start_plan(self, selected):
+        self._require_scope(self.PERSON_SCOPE)
+        self._write_line('<plan selected="%s">' % self.yes_no(selected))
+        self.indent += 1
+        self.scope = self.PLAN_SCOPE
+
+    def end_plan(self):
+        self._require_scope(self.PLAN_SCOPE)
+        self.indent -= 1
+        self.scope = self.PERSON_SCOPE
+        self._write_line('</plan>')
+
+    def add_activity(self, type, location, start_time = None, end_time = None):
+        self._require_scope(self.PLAN_SCOPE)
+
+        self._write_indent()
+        self._write('<activity ')
+        self._write('type="%s" ' % type)
+        self._write('x="%f" y="%f" ' % (location[0], location[1]))
+        if location[2] is not None: self._write('facility="%s" ' % str(location[2]))
+        if start_time is not None: self._write('start_time="%s" ' % self.time(start_time))
+        if end_time is not None: self._write('end_time="%s" ' % self.time(end_time))
+        self._write('/>\n')
+
+    def add_leg(self, mode, departure_time, travel_time):
+        self._require_scope(self.PLAN_SCOPE)
+
+        self._write_indent()
+        self._write('<leg ')
+        self._write('mode="%s" ' % mode)
+        self._write('dep_time="%s" ' % self.time(departure_time))
+        self._write('trav_time="%s" ' % self.time(travel_time))
+        self._write('/>\n')
+
+
+class HouseholdsWriter(XmlWriter):
+    HOUSEHOLDS_SCOPE = 0
+    FINISHED_SCOPE = 1
+    HOUSEHOLD_SCOPE = 2
+    ATTRIBUTES_SCOPE = 3
+
+    def __init__(self, writer):
+        XmlWriter.__init__(self, writer)
+
+    def start_households(self, attributes = {}):
+        self._require_scope(None)
+        self._write_line('<?xml version="1.0" encoding="utf-8"?>')
+        self._write_line('<households xmlns="http://www.matsim.org/files/dtd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/households_v1.0.xsd">')
+
+        self.scope = self.HOUSEHOLDS_SCOPE
+        self.indent += 1
+
+        _write_preface_attributes(self, attributes)
+
+    def end_households(self):
+        self._require_scope(self.HOUSEHOLDS_SCOPE)
+        self._write_line('</households>')
+        self.scope = self.FINISHED_SCOPE
+
+    def start_household(self, household_id):
+        self._require_scope(self.HOUSEHOLDS_SCOPE)
+        self._write_line('<household id="%d">' % household_id)
+        self.scope = self.HOUSEHOLD_SCOPE
+        self.indent += 1
+
+    def end_household(self):
+        self._require_scope(self.HOUSEHOLD_SCOPE)
+        self.indent -= 1
+        self.scope = self.HOUSEHOLDS_SCOPE
+        self._write_line('</household>')
+
+    def start_attributes(self):
+        self._require_scope(self.HOUSEHOLD_SCOPE)
+        self._write_line('<attributes>')
+        self.indent += 1
+        self.scope = self.ATTRIBUTES_SCOPE
+
+    def end_attributes(self):
+        self._require_scope(self.ATTRIBUTES_SCOPE)
+        self.indent -= 1
+        self.scope = self.HOUSEHOLD_SCOPE
+        self._write_line('</attributes>')
+
+    def add_attribute(self, name, type, value):
+        self._require_scope(self.ATTRIBUTES_SCOPE)
+        self._write_line('<attribute name="%s" class="%s">%s</attribute>' % (
+            name, type, value
+        ))
+
+    def add_members(self, person_ids):
+        self._require_scope(self.HOUSEHOLD_SCOPE)
+        self._write_line('<members>')
+        self.indent += 1
+        for person_id in person_ids: self._write_line('<personId refId="%s" />' % person_id)
+        self.indent -= 1
+        self._write_line('</members>')
+
+    def add_income(self, income):
+        self._require_scope(self.HOUSEHOLD_SCOPE)
+        self._write_line('<income currency="CHF" period="month">%f</income>' % income)
+
+
+class FacilitiesWriter(XmlWriter):
+    FACILITIES_SCOPE = 0
+    FINISHED_SCOPE = 1
+    FACILITY_SCOPE = 2
+
+    def __init__(self, writer):
+        XmlWriter.__init__(self, writer)
+
+    def start_facilities(self, attributes = {}):
+        self._require_scope(None)
+        self._write_line('<?xml version="1.0" encoding="utf-8"?>')
+        self._write_line('<!DOCTYPE facilities SYSTEM "http://www.matsim.org/files/dtd/facilities_v1.dtd">')
+        self._write_line('<facilities>')
+
+        self.scope = self.FACILITIES_SCOPE
+        self.indent += 1
+
+        _write_preface_attributes(self, attributes)
+
+    def end_facilities(self):
+        self._require_scope(self.FACILITIES_SCOPE)
+        self.indent -= 1
+        self._write_line('</facilities>')
+        self.scope = self.FINISHED_SCOPE
+
+    def start_facility(self, facility_id, x, y):
+        self._require_scope(self.FACILITIES_SCOPE)
+        self._write_line('<facility id="%s" x="%f" y="%f">' % (
+            str(facility_id), x, y
+        ))
+
+        self.indent += 1
+        self.scope = self.FACILITY_SCOPE
+
+    def end_facility(self):
+        self._require_scope(self.FACILITY_SCOPE)
+        self.indent -= 1
+        self.scope = self.FACILITIES_SCOPE
+        self._write_line('</facility>')
+
+    def add_activity(self, purpose):
+        self._require_scope(self.FACILITY_SCOPE)
+        self._write_line('<activity type="%s" />' % purpose)
+
+
+class backlog_iterator:
+    def __init__(self, iterable, backlog = 1):
+        self.iterable = iterable
+        self.forward_log = []
+        self.backward_log = [None] * (backlog + 1)
+
+    def next(self):
+        if len(self.forward_log) > 0:
+            self.backward_log.append(self.forward_log[0])
+            del self.forward_log[0]
+        else:
+            self.backward_log.append(next(self.iterable))
+
+        del self.backward_log[0]
+        return self.backward_log[-1]
+
+    def previous(self):
+        self.forward_log.insert(0, self.backward_log[-1])
+        del self.backward_log[-1]
+        self.backward_log.insert(0, None)
+        return self.backward_log[-1]
+
+    def current(self):
+        return self.backlog[-1]
+
+    def has_previous(self):
+        return len(self.backward_log) > 1
+
+    def has_next(self):
+        if len(self.forward_log) > 0:
+            return True
+
+        try:
+            self.forward_log.append(next(self.iterable))
+            return True
+        except StopIteration:
+            return False

--- a/matsim/writers.py
+++ b/matsim/writers.py
@@ -1,39 +1,48 @@
 import numpy as np
+from typing import Dict, Union, Collection, TypeVar
+
+Id = TypeVar('Id', str, int)
 
 
 class XmlWriter:
+    NO_SCOPE = -1
+    JAVA_ATT_TYPES = {str: "java.lang.String",
+                      int: "java.lang.Integer",
+                      float: "java.lang.Double",
+                      bool: "java.lang.Boolean"}
+
     def __init__(self, writer):
         self.writer = writer
         self.indent = 0
-        self.scope = None
+        self.scope = self.NO_SCOPE
 
-    def _write_line(self, content):
+    def _write_line(self, content: str):
         self._write_indent()
         self._write(content + "\n")
 
     def _write_indent(self):
         self._write("  " * self.indent)
 
-    def _write(self, content):
+    def _write(self, content: str):
         self.writer.write(bytes(content, "utf-8"))
 
-    def _require_scope(self, scope):
-        if not scope and self.scope is not None:
+    def _require_scope(self, scope: int):
+        if scope == self.NO_SCOPE and self.scope != self.NO_SCOPE:
             raise RuntimeError("Expected initial scope")
 
         if not self.scope == scope:
             raise RuntimeError("Expected different scope")
 
     @staticmethod
-    def yes_no(value):
+    def yes_no(value: bool):
         return "yes" if value else "no"
 
     @staticmethod
-    def true_false(self, value):
+    def true_false(value: bool):
         return "true" if value else "false"
 
     @staticmethod
-    def time(time):
+    def time(time: int):
         if np.isnan(time):
             return None
 
@@ -41,19 +50,15 @@ class XmlWriter:
         hours = time // 3600
         minutes = (time % 3600) // 60
         seconds = (time % 60)
-        return "%02d:%02d:%02d" % (hours, minutes, seconds)
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 
-    @staticmethod
-    def location(x, y, facility_id=None):
-        return x, y, None if facility_id is None else facility_id
-
-    def _write_preface_attributes(self, attributes=None):
+    def _write_preface_attributes(self, attributes: Dict[str, str] = None):
         if attributes:
             self._write_line('<attributes>')
             self.indent += 1
 
-            for item in attributes.items():
-                self._write_line('<attribute name="%s" class="java.lang.String">%s</attribute>' % item)
+            for name, value in attributes.items():
+                self._write_line(f'<attribute name="{name}" class="java.lang.String">{value}</attribute>')
 
             self.indent -= 1
             self._write_line('</attributes>')
@@ -69,8 +74,8 @@ class PopulationWriter(XmlWriter):
     def __init__(self, writer):
         XmlWriter.__init__(self, writer)
 
-    def start_population(self, attributes=None):
-        self._require_scope(None)
+    def start_population(self, attributes: Dict[str, str] = None):
+        self._require_scope(self.NO_SCOPE)
         self._write_line('<?xml version="1.0" encoding="utf-8"?>')
         self._write_line('<!DOCTYPE population SYSTEM "http://www.matsim.org/files/dtd/population_v6.dtd">')
         self._write_line('<population>')
@@ -84,9 +89,9 @@ class PopulationWriter(XmlWriter):
         self._write_line('</population>')
         self.scope = self.FINISHED_SCOPE
 
-    def start_person(self, person_id):
+    def start_person(self, person_id: Id):
         self._require_scope(self.POPULATION_SCOPE)
-        self._write_line('<person id="%d">' % person_id)
+        self._write_line(f'<person id="{person_id}">')
         self.scope = self.PERSON_SCOPE
         self.indent += 1
 
@@ -108,15 +113,15 @@ class PopulationWriter(XmlWriter):
         self.scope = self.PERSON_SCOPE
         self._write_line('</attributes>')
 
-    def add_attribute(self, name, type, value):
+    def add_attribute(self, name: str, value: Union[str, int, float, bool], typ: str = None):
+        if not typ:
+            typ = self.JAVA_ATT_TYPES[type(value)]
         self._require_scope(self.ATTRIBUTES_SCOPE)
-        self._write_line('<attribute name="%s" class="%s">%s</attribute>' % (
-            name, type, value
-        ))
+        self._write_line(f'<attribute name="{name}" class="{typ}">{value}</attribute>')
 
-    def start_plan(self, selected):
+    def start_plan(self, selected: bool):
         self._require_scope(self.PERSON_SCOPE)
-        self._write_line('<plan selected="%s">' % self.yes_no(selected))
+        self._write_line(f'<plan selected="{self.yes_no(selected)}">')
         self.indent += 1
         self.scope = self.PLAN_SCOPE
 
@@ -126,24 +131,25 @@ class PopulationWriter(XmlWriter):
         self.scope = self.PERSON_SCOPE
         self._write_line('</plan>')
 
-    def add_activity(self, type, location, start_time=None, end_time=None):
+    def add_activity(self, type: str, x: float, y: float, facility_id: str = None,
+                     start_time: int = None, end_time: int = None):
         self._require_scope(self.PLAN_SCOPE)
         self._write_indent()
         self._write('<activity ')
-        self._write('type="%s" ' % type)
-        self._write('x="%f" y="%f" ' % (location[0], location[1]))
-        if location[2] is not None: self._write('facility="%s" ' % str(location[2]))
-        if start_time is not None: self._write('start_time="%s" ' % self.time(start_time))
-        if end_time is not None: self._write('end_time="%s" ' % self.time(end_time))
+        self._write(f'type="{type}" ')
+        self._write(f'x="{x}" y="{y}" ')
+        if facility_id: self._write(f'facility="{facility_id}" ')
+        if start_time: self._write(f'start_time="{self.time(start_time)}" ')
+        if end_time: self._write(f'end_time="{self.time(end_time)}" ')
         self._write('/>\n')
 
-    def add_leg(self, mode, departure_time, travel_time):
+    def add_leg(self, mode: str, departure_time: int, travel_time: int):
         self._require_scope(self.PLAN_SCOPE)
         self._write_indent()
         self._write('<leg ')
-        self._write('mode="%s" ' % mode)
-        self._write('dep_time="%s" ' % self.time(departure_time))
-        self._write('trav_time="%s" ' % self.time(travel_time))
+        self._write(f'mode="{mode}" ')
+        self._write(f'dep_time="{self.time(departure_time)}" ')
+        self._write(f'trav_time="{self.time(travel_time)}" ')
         self._write('/>\n')
 
 
@@ -157,7 +163,7 @@ class HouseholdsWriter(XmlWriter):
         XmlWriter.__init__(self, writer)
 
     def start_households(self, attributes=None):
-        self._require_scope(None)
+        self._require_scope(self.NO_SCOPE)
         self._write_line('<?xml version="1.0" encoding="utf-8"?>')
         self._write_line('<households xmlns="http://www.matsim.org/files/dtd" '
                          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
@@ -172,9 +178,9 @@ class HouseholdsWriter(XmlWriter):
         self._write_line('</households>')
         self.scope = self.FINISHED_SCOPE
 
-    def start_household(self, household_id):
+    def start_household(self, household_id: Id):
         self._require_scope(self.HOUSEHOLDS_SCOPE)
-        self._write_line('<household id="%d">' % household_id)
+        self._write_line(f'<household id="{household_id}">')
         self.scope = self.HOUSEHOLD_SCOPE
         self.indent += 1
 
@@ -196,24 +202,24 @@ class HouseholdsWriter(XmlWriter):
         self.scope = self.HOUSEHOLD_SCOPE
         self._write_line('</attributes>')
 
-    def add_attribute(self, name, type, value):
+    def add_attribute(self, name: str, value: Union[str, int, float, bool], typ: str = None):
+        if not typ:
+            typ = self.JAVA_ATT_TYPES[type(value)]
         self._require_scope(self.ATTRIBUTES_SCOPE)
-        self._write_line('<attribute name="%s" class="%s">%s</attribute>' % (
-            name, type, value
-        ))
+        self._write_line(f'<attribute name="{name}" class="{typ}">{value}</attribute>')
 
-    def add_members(self, person_ids):
+    def add_members(self, person_ids: Collection[Id]):
         self._require_scope(self.HOUSEHOLD_SCOPE)
         self._write_line('<members>')
         self.indent += 1
         for person_id in person_ids:
-            self._write_line('<personId refId="%s" />' % person_id)
+            self._write_line(f'<personId refId="{person_id}" />')
         self.indent -= 1
         self._write_line('</members>')
 
-    def add_income(self, income):
+    def add_income(self, income: Union[float, int]):
         self._require_scope(self.HOUSEHOLD_SCOPE)
-        self._write_line('<income currency="CHF" period="month">%f</income>' % income)
+        self._write_line(f'<income currency="CHF" period="month">{income}</income>')
 
 
 class FacilitiesWriter(XmlWriter):
@@ -225,7 +231,7 @@ class FacilitiesWriter(XmlWriter):
         XmlWriter.__init__(self, writer)
 
     def start_facilities(self, attributes=None):
-        self._require_scope(None)
+        self._require_scope(self.NO_SCOPE)
         self._write_line('<?xml version="1.0" encoding="utf-8"?>')
         self._write_line('<!DOCTYPE facilities SYSTEM "http://www.matsim.org/files/dtd/facilities_v1.dtd">')
         self._write_line('<facilities>')
@@ -240,11 +246,9 @@ class FacilitiesWriter(XmlWriter):
         self._write_line('</facilities>')
         self.scope = self.FINISHED_SCOPE
 
-    def start_facility(self, facility_id, x, y):
+    def start_facility(self, facility_id: Id, x: float, y: float):
         self._require_scope(self.FACILITIES_SCOPE)
-        self._write_line('<facility id="%s" x="%f" y="%f">' % (
-            str(facility_id), x, y
-        ))
+        self._write_line(f'<facility id="{facility_id}" x="{x}" y="{y}">')
         self.indent += 1
         self.scope = self.FACILITY_SCOPE
 
@@ -254,7 +258,7 @@ class FacilitiesWriter(XmlWriter):
         self.scope = self.FACILITIES_SCOPE
         self._write_line('</facility>')
 
-    def add_activity(self, purpose):
+    def add_activity(self, purpose: str):
         self._require_scope(self.FACILITY_SCOPE)
-        self._write_line('<activity type="%s" />' % purpose)
+        self._write_line(f'<activity type="{purpose}" />')
 


### PR DESCRIPTION
As discussed in https://github.com/matsim-vsp/matsim-python-tools/issues/6 , this PR simply makes the writers.py class from https://github.com/eqasim-org/ile-de-france/blob/develop/matsim/writers.py available to the users of this project. 
I wanted to push also some additional utilities that actually uses it instead of simply pushing the class but I realized a more advanced and generalized solution would require more reflection time (first question: data format??). 
I played around a bit with them, and the classes in writers.py are quite easy to use and flexible, so it is surely a good start. We need here to put such a writer in production so the experience will bring new ideas.
A nice next step could be to write a test that reads an XML and writes it back to XML (and check that both match), possibly with dataframes in-between. 
@sebhoerl: I did some minor changes already, as can be seen in the commits.
Let me know what you think! 
