### PR TITLE
Fix memory leak in ElementTree.iterparse

### DIFF
--- a/matsim/Events.py
+++ b/matsim/Events.py
@@ -55,18 +55,19 @@ def event_reader(filepath, types=None):
 def _event_reader_xml(filepath):
     """ Any content text of the XML element itself is dropped, as MATSim events are attribute-only. """
     with xopen(filepath) as f:
-        tree = ET.iterparse(f)
+        tree = ET.iterparse(f, events=['start', 'end'])
+        _, root = next(tree)
         try:
             for xml_event, elem in tree:
                 attributes = elem.attrib
 
-                if elem.tag == 'event':
+                if xml_event == 'start' and elem.tag == 'event':
                     # got one! yield the event to the caller
                     attributes['time'] = float(attributes['time'])
                     yield attributes
 
                 # free memory. Otherwise the data is kept in memory and we loose the advantage of streaming
-                elem.clear()
+                root.clear()
 
         except Exception as e:
             # Why am I catching this exception instead of allowing it to propagate up?


### PR DESCRIPTION
Hi, I found a memory leak issue, and this PR fixes it.

### Background

I tried to read a huge output_event.xml.gz over 3GB using event reader, then OOM killer killed the process on my machine which has 32GB RAM. 
After the investigation I found memory leak of the process using [memory profiler].


### Memory usage

#### Before

![mprof-matsim](https://user-images.githubusercontent.com/451586/152521261-444bf88b-5248-4f14-a2a4-38bf163b933e.png)

#### After the fix

![mprof-fixed-matsim](https://user-images.githubusercontent.com/451586/152521377-253ddf39-0402-4a7b-9a61-8cd77f9f9f2a.png)

### the test code (memleak.py)

```python
#!/usr/bin/env python                                                                                                                                                                                                                                                                       
import matsim                                                                                                                                                                                                                                                                               
from memory_profiler import profile                                                                                                                                                                                                                                                         
import xml.etree.ElementTree as ET

event_file = 'tmp/simulation/output_events.xml.gz'                                                                                                                                                                                                                                          
cnt = 1000000                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                            
@profile                                                                                                                                                                                                                                                                                    
def run_matsim():                                                                                                                                                                                                                                                                           
    i = 0                                                                                                                                                                                                                                                                                   
    for event in matsim.event_reader(event_file):                                                                                                                                                                                                                                           
        i += 1                                                                                                                                                                                                                                                                              
        if i > cnt:                                                                                                                                                                                                                                                                         
            break                                                                                                                                                                                                                                                                           
```

### show a memory usage graph

```
mprof run ./memleak.py        # run w/ profile
mprof plot                 # make a graph
```

[memory profiler]: https://pypi.org/project/memory-profiler/