### PR TITLE
Add a function to return plan file as a dataframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ dist/
 *.egg-info
 .ipynb_checkpoints
 .build-sentinel
-
+.vscode

--- a/matsim/Plans.py
+++ b/matsim/Plans.py
@@ -45,13 +45,13 @@ def _parseAttributes(elem, dict):
         dict[attrib] = elem.attrib[attrib]
     return dict
 
-# Returns dataframes with the following columns:
-# Person : ['id', 'age', 'bikeAvailability', 'carAvailability', 'censusHouseholdId', 'censusPersonId', 'employed', 'hasLicense', 'hasPtSubscription', 'householdId', 'householdIncome', 'htsHouseholdId', 'htsPersonId', 'isOutside', 'isPassenger', 'motorbikesAvailability', 'sex']
-# Plan : ['id', 'person_id', 'score', 'selected']
-# Activity : ['id', 'plan_id', 'type', 'link', 'facility', 'x', 'y', 'z', 'end_time', 'start_time', 'max_dur', 'typeBeforeCutting']
-# Leg : ['id', 'plan_id', 'mode', 'dep_time', 'trav_time', 'routingMode']
-# Route :
-# TODO  - Add an option to disable parsing <attribute> xml elements
+# Returns dataframes with the following relations between them:
+# Person : None
+# Plan : person_id
+# Activity : plan_id
+# Leg : plan_id
+# Route :leg_id
+# The column names of the dataframes are the same as the attribute names (<name:'value'> and <attribute> are parsed)
 def plan_reader_dataframe(filename, selectedPlansOnly = False):
     tree = ET.iterparse(xopen.xopen(filename), events=['start','end'])
     

--- a/matsim/Plans.py
+++ b/matsim/Plans.py
@@ -1,13 +1,12 @@
 import xopen
 import xml.etree.ElementTree as ET
+import pandas as pd
 
 def plan_reader(filename, selectedPlansOnly = False):
-
     person = None
     tree = ET.iterparse(xopen.xopen(filename), events=['start','end'])
-
+    
     for xml_event, elem in tree:
-        
         if elem.tag == 'person' and xml_event == 'start':
             # keep track of whether a person node has any plans
             this_person_has_plans = False
@@ -31,3 +30,139 @@ def plan_reader(filename, selectedPlansOnly = False):
             if not this_person_has_plans:
                 yield (person, None)
 
+# Parses attributes of an element and adds them to the given dictionary
+def _parseAttributes(elem, dict):
+    for attrib in elem.attrib:
+        dict[attrib] = elem.attrib[attrib]
+    return dict
+
+# Returns dataframes with the following columns:
+# Person : ['id', 'age', 'bikeAvailability', 'carAvailability', 'censusHouseholdId', 'censusPersonId', 'employed', 'hasLicense', 'hasPtSubscription', 'householdId', 'householdIncome', 'htsHouseholdId', 'htsPersonId', 'isOutside', 'isPassenger', 'motorbikesAvailability', 'sex']
+# Plan : ['id', 'person_id', 'score', 'selected']
+# Activity : ['id', 'plan_id', 'type', 'link', 'facility', 'x', 'y', 'z', 'end_time', 'start_time', 'max_dur', 'typeBeforeCutting']
+# Leg : ['id', 'plan_id', 'mode', 'dep_time', 'trav_time', 'routingMode']
+# Route :
+# TODO  - Add an option to disable parsing <attribute> xml elements
+def plan_reader_dataframe(filename, selectedPlansOnly = False):
+    tree = ET.iterparse(xopen.xopen(filename), events=['start','end'])
+    
+    persons = []
+    plans = []
+    activities = []
+    legs = []
+    routes = []
+    
+    currentPerson = {}
+    currentPlan = {}
+    currentActivity = {}
+    currentLeg = {}
+    currentRoute = {}
+    
+    # Indicates current parent element while parsing <attribute> element
+    isParsingPerson = False
+    isParsingActivity = False
+    isParsingLeg = False
+    
+    currentPersonId = None
+    currentPlanId = 0
+    currentActivityId = 0
+    currentLegId = 0
+    currentRouteId = 0
+    
+    for xml_event, elem in tree:
+        if elem.tag in ['person', 'leg', 'activity'] and xml_event == 'end':
+            if isParsingPerson:
+                persons.append(currentPerson)
+                currentPerson = {}
+                isParsingPerson = False
+            
+            if isParsingActivity:
+                activities.append(currentActivity)
+                currentActivity = {}
+                isParsingActivity = False
+            
+            if isParsingLeg:
+                legs.append(currentLeg)
+                currentLeg = {}
+                isParsingLeg = False
+            
+            elem.clear()
+        
+        # PERSON
+        elif elem.tag == 'person':
+            currentPerson['id'] = elem.attrib['id']
+            currentPersonId = elem.attrib['id']
+            isParsingPerson = True
+        
+        # PLAN
+        elif elem.tag == 'plan':
+            currentPlanId += 1
+            
+            currentPlan['id'] = currentPlanId
+            currentPlan['person_id'] = currentPersonId
+            currentPlan = _parseAttributes(elem, currentPlan)
+            
+            plans.append(currentPlan)
+            currentPlan = {}
+            elem.clear()
+        
+        # ACTIVITY
+        elif elem.tag == 'activity':
+            isParsingActivity = True
+            currentActivityId += 1
+            
+            currentActivity['id'] = currentActivityId
+            currentActivity['plan_id'] = currentPlanId
+            currentActivity = _parseAttributes(elem, currentActivity)
+            
+        
+        # LEG
+        elif elem.tag == 'leg':
+            isParsingLeg = True
+            currentLegId += 1
+            
+            currentLeg['id'] = currentLegId
+            currentLeg['plan_id'] = currentPlanId
+            currentLeg = _parseAttributes(elem, currentLeg)
+        
+        
+        # ROUTE
+        elif elem.tag == 'route':
+            currentRouteId += 1
+            
+            currentRoute['id'] = currentRouteId
+            currentRoute['leg_id'] = currentLegId
+            currentRoute['value'] = elem.text
+            currentRoute = _parseAttributes(elem, currentRoute)
+            
+            routes.append(currentRoute)
+            currentRoute = {}
+            elem.clear()
+        
+        
+        # ATTRIBUTES
+        elif elem.tag == 'attribute' and xml_event == 'end':
+            attribs = elem.attrib
+            
+            if isParsingActivity:
+                currentActivity[attribs['name']] = elem.text
+                
+            elif isParsingLeg:
+                currentLeg[attribs['name']] = elem.text
+            
+            elif isParsingPerson: # Parsing person
+                currentPerson[attribs['name']] = elem.text
+    
+    persons = pd.DataFrame.from_records(persons)
+    plans = pd.DataFrame.from_records(plans)
+    activities = pd.DataFrame.from_records(activities)
+    legs = pd.DataFrame.from_records(legs)
+    routes = pd.DataFrame.from_records(routes)
+    
+    print(persons.head())
+    print(plans.head())
+    print(activities.head(30))
+    print(legs.head())
+    print(routes.head())
+    # return persons
+    

--- a/matsim/Plans.py
+++ b/matsim/Plans.py
@@ -11,7 +11,7 @@ class Plans:
         self.legs = legs
         self.routes = routes
 
-def plan_reader(filename, selectedPlansOnly = False):
+def plan_reader(filename, selected_plans_only = False):
     person = None
     tree = ET.iterparse(xopen.xopen(filename), events=['start','end'])
     
@@ -27,7 +27,7 @@ def plan_reader(filename, selectedPlansOnly = False):
             this_person_has_plans = True
 
             # filter out unselected plans if asked to do so
-            if selectedPlansOnly and elem.attrib['selected'] == 'no': continue
+            if selected_plans_only and elem.attrib['selected'] == 'no': continue
 
             yield (person, elem)
 
@@ -52,7 +52,7 @@ def _parseAttributes(elem, dict):
 # Leg : plan_id
 # Route :leg_id
 # The column names of the dataframes are the same as the attribute names (<name:'value'> and <attribute> are parsed)
-def plan_reader_dataframe(filename, selectedPlansOnly = False):
+def plan_reader_dataframe(filename, selected_plans_only = False):
     tree = ET.iterparse(xopen.xopen(filename), events=['start','end'])
     
     persons = []
@@ -61,108 +61,108 @@ def plan_reader_dataframe(filename, selectedPlansOnly = False):
     legs = []
     routes = []
     
-    currentPerson = {}
-    currentPlan = {}
-    currentActivity = {}
-    currentLeg = {}
-    currentRoute = {}
+    current_person = {}
+    current_plan = {}
+    current_activity = {}
+    current_leg = {}
+    current_route = {}
     
     # Indicates current parent element while parsing <attribute> element
-    isParsingPerson = False
-    isParsingActivity = False
-    isParsingLeg = False
+    is_parsing_person = False
+    is_parsing_activity = False
+    is_parsing_leg = False
     
-    currentPersonId = None
-    currentPlanId = 0
-    currentActivityId = 0
-    currentLegId = 0
-    currentRouteId = 0
+    current_person_id = None
+    current_plan_id = 0
+    current_activity_id = 0
+    current_leg_id = 0
+    current_route_id = 0
     
     for xml_event, elem in tree:
         if elem.tag in ['person', 'leg', 'activity', 'plan', 'route'] and xml_event == 'end':
-            if isParsingPerson:
-                persons.append(currentPerson)
-                currentPerson = {}
-                isParsingPerson = False
+            if is_parsing_person:
+                persons.append(current_person)
+                current_person = {}
+                is_parsing_person = False
             
-            if isParsingActivity:
-                activities.append(currentActivity)
-                currentActivity = {}
-                isParsingActivity = False
+            if is_parsing_activity:
+                activities.append(current_activity)
+                current_activity = {}
+                is_parsing_activity = False
             
-            if isParsingLeg:
-                legs.append(currentLeg)
-                currentLeg = {}
-                isParsingLeg = False
+            if is_parsing_leg:
+                legs.append(current_leg)
+                current_leg = {}
+                is_parsing_leg = False
             
             if elem.tag == 'plan':
-                if elem.attrib['selected'] == 'no' and selectedPlansOnly: continue
-                plans.append(currentPlan)
-                currentPlan = {}
+                if elem.attrib['selected'] == 'no' and selected_plans_only: continue
+                plans.append(current_plan)
+                current_plan = {}
                 
             if elem.tag == 'route':
-                routes.append(currentRoute)
-                currentRoute = {}
+                routes.append(current_route)
+                current_route = {}
             
             elem.clear()
         
         # PERSON
         elif elem.tag == 'person':
-            currentPerson['id'] = elem.attrib['id']
-            currentPersonId = elem.attrib['id']
-            isParsingPerson = True
+            current_person['id'] = elem.attrib['id']
+            current_person_id = elem.attrib['id']
+            is_parsing_person = True
         
         # PLAN
         elif elem.tag == 'plan':
-            if elem.attrib['selected'] == 'no' and selectedPlansOnly: continue
-            currentPlanId += 1
+            if elem.attrib['selected'] == 'no' and selected_plans_only: continue
+            current_plan_id += 1
             
-            currentPlan['id'] = currentPlanId
-            currentPlan['person_id'] = currentPersonId
-            currentPlan = _parseAttributes(elem, currentPlan)
+            current_plan['id'] = current_plan_id
+            current_plan['person_id'] = current_person_id
+            current_plan = _parseAttributes(elem, current_plan)
         
         # ACTIVITY
         elif elem.tag == 'activity':
-            isParsingActivity = True
-            currentActivityId += 1
+            is_parsing_activity = True
+            current_activity_id += 1
             
-            currentActivity['id'] = currentActivityId
-            currentActivity['plan_id'] = currentPlanId
-            currentActivity = _parseAttributes(elem, currentActivity)
+            current_activity['id'] = current_activity_id
+            current_activity['plan_id'] = current_plan_id
+            current_activity = _parseAttributes(elem, current_activity)
             
         
         # LEG
         elif elem.tag == 'leg':
-            isParsingLeg = True
-            currentLegId += 1
+            is_parsing_leg = True
+            current_leg_id += 1
             
-            currentLeg['id'] = currentLegId
-            currentLeg['plan_id'] = currentPlanId
-            currentLeg = _parseAttributes(elem, currentLeg)
+            current_leg['id'] = current_leg_id
+            current_leg['plan_id'] = current_plan_id
+            current_leg = _parseAttributes(elem, current_leg)
         
         
         # ROUTE
         elif elem.tag == 'route':
-            currentRouteId += 1
+            current_route_id += 1
             
-            currentRoute['id'] = currentRouteId
-            currentRoute['leg_id'] = currentLegId
-            currentRoute['value'] = elem.text
-            currentRoute = _parseAttributes(elem, currentRoute)
+            current_route['id'] = current_route_id
+            current_route['leg_id'] = current_leg_id
+            current_route['value'] = elem.text
+            current_route = _parseAttributes(elem, current_route)
         
         
         # ATTRIBUTES
         elif elem.tag == 'attribute' and xml_event == 'end':
             attribs = elem.attrib
             
-            if isParsingActivity:
-                currentActivity[attribs['name']] = elem.text
+            if is_parsing_activity:
+                current_activity[attribs['name']] = elem.text
                 
-            elif isParsingLeg:
-                currentLeg[attribs['name']] = elem.text
+            elif is_parsing_leg:
+                current_leg[attribs['name']] = elem.text
             
-            elif isParsingPerson: # Parsing person
-                currentPerson[attribs['name']] = elem.text
+            elif is_parsing_person: # Parsing person
+                current_person[attribs['name']] = elem.text
     
     persons = pd.DataFrame.from_records(persons)
     plans = pd.DataFrame.from_records(plans)

--- a/matsim/__init__.py
+++ b/matsim/__init__.py
@@ -3,3 +3,4 @@ from . import Events, Network, Plans, TripEventHandler, writers
 read_network = Network.read_network
 event_reader = Events.event_reader
 plan_reader = Plans.plan_reader
+plan_reader_dataframe = Plans.plan_reader_dataframe

--- a/tests/test_MatsimPlansReader.py
+++ b/tests/test_MatsimPlansReader.py
@@ -36,7 +36,7 @@ def test_plan_reader_selected_only(filepath):
     count_people = defaultdict(int)
     count_plans = defaultdict(int)
     
-    plans = Plans.plan_reader(HERE / filepath, selectedPlansOnly = True)
+    plans = Plans.plan_reader(HERE / filepath, selected_plans_only = True)
 
     for person,plan in plans:
         print(person)
@@ -60,23 +60,23 @@ def test_non_existent():
 
 @pytest.mark.parametrize('filepath', files)
 def test_plan_reader_dataframe(filepath):
-    selectedPlansCases = [True, False]
+    selected_plans_cases = [True, False]
     
-    for selectedPlansOnly in selectedPlansCases:
-        plansDataframes = Plans.plan_reader_dataframe(HERE / filepath, selectedPlansOnly)
+    for selected_plans_only in selected_plans_cases:
+        plans_dataframes = Plans.plan_reader_dataframe(HERE / filepath, selected_plans_only)
         
-        persons = plansDataframes.persons
-        plans = plansDataframes.plans
-        activities = plansDataframes.activities
-        legs = plansDataframes.legs
-        routes = plansDataframes.routes
+        persons = plans_dataframes.persons
+        plans = plans_dataframes.plans
+        activities = plans_dataframes.activities
+        legs = plans_dataframes.legs
+        routes = plans_dataframes.routes
         
-        personsExpectedColumnsFull = ['id', 'home-activity-zone', 'subpopulation']
-        personsExpectedColumnsEmpty = ['id', 'age', 'district', 'homeId', 'homeX', 'homeY', 'sex']
-        plansExpectedColumns = ['id', 'person_id', 'score', 'selected']
-        activitesExpectedColumns = ['id', 'plan_id', 'type', 'link', 'x', 'y', 'end_time', 'zoneId', 'max_dur', 'cemdapStopDuration_s']
-        legsExpectedColumns = ['id', 'plan_id', 'mode', 'dep_time']
-        routesExpectedColumns = ['id', 'leg_id', 'value', 'type', 'start_link', 'end_link', 'trav_time', 'distance', 'vehicleRefId']
+        persons_expected_columns_full = ['id', 'home-activity-zone', 'subpopulation']
+        persons_expected_columns_empty = ['id', 'age', 'district', 'homeId', 'homeX', 'homeY', 'sex']
+        plans_expected_columns = ['id', 'person_id', 'score', 'selected']
+        activites_expected_columns = ['id', 'plan_id', 'type', 'link', 'x', 'y', 'end_time', 'zoneId', 'max_dur', 'cemdapStopDuration_s']
+        legs_expected_columns = ['id', 'plan_id', 'mode', 'dep_time']
+        routes_expected_columns = ['id', 'leg_id', 'value', 'type', 'start_link', 'end_link', 'trav_time', 'distance', 'vehicleRefId']
         
         if filepath == 'plans_empty.xml.gz':
             assert len(persons) == 3
@@ -84,7 +84,7 @@ def test_plan_reader_dataframe(filepath):
             assert len(activities) == 0
             assert len(legs) == 0
             assert len(routes) == 0
-            np.testing.assert_array_equal(personsExpectedColumnsEmpty, persons.keys())
+            np.testing.assert_array_equal(persons_expected_columns_empty, persons.keys())
             np.testing.assert_array_equal([], plans.keys())
             np.testing.assert_array_equal([], activities.keys())
             np.testing.assert_array_equal([], legs.keys())
@@ -93,7 +93,7 @@ def test_plan_reader_dataframe(filepath):
         else:
             assert len(persons) == 3
             
-            if selectedPlansOnly:
+            if selected_plans_only:
                 assert len(plans) == 3
             else:
                 assert len(plans) == 4
@@ -101,8 +101,8 @@ def test_plan_reader_dataframe(filepath):
             assert len(activities) == 39
             assert len(legs) == 35
             assert len(routes) == 35
-            np.testing.assert_array_equal(personsExpectedColumnsFull, persons.keys())
-            np.testing.assert_array_equal(plansExpectedColumns, plans.keys())
-            np.testing.assert_array_equal(activitesExpectedColumns, activities.keys())
-            np.testing.assert_array_equal(legsExpectedColumns, legs.keys())
-            np.testing.assert_array_equal(routesExpectedColumns, routes.keys())
+            np.testing.assert_array_equal(persons_expected_columns_full, persons.keys())
+            np.testing.assert_array_equal(plans_expected_columns, plans.keys())
+            np.testing.assert_array_equal(activites_expected_columns, activities.keys())
+            np.testing.assert_array_equal(legs_expected_columns, legs.keys())
+            np.testing.assert_array_equal(routes_expected_columns, routes.keys())

--- a/tests/test_MatsimPlansReader.py
+++ b/tests/test_MatsimPlansReader.py
@@ -1,6 +1,7 @@
 import pytest
 import pathlib
-
+import pandas as pd
+import numpy as np
 from collections import defaultdict
 
 from matsim import Plans
@@ -57,3 +58,51 @@ def test_non_existent():
         for _ in plans:
             pass
 
+@pytest.mark.parametrize('filepath', files)
+def test_plan_reader_dataframe(filepath):
+    selectedPlansCases = [True, False]
+    
+    for selectedPlansOnly in selectedPlansCases:
+        plansDataframes = Plans.plan_reader_dataframe(HERE / filepath, selectedPlansOnly)
+        
+        persons = plansDataframes.persons
+        plans = plansDataframes.plans
+        activities = plansDataframes.activities
+        legs = plansDataframes.legs
+        routes = plansDataframes.routes
+        
+        personsExpectedColumnsFull = ['id', 'home-activity-zone', 'subpopulation']
+        personsExpectedColumnsEmpty = ['id', 'age', 'district', 'homeId', 'homeX', 'homeY', 'sex']
+        plansExpectedColumns = ['id', 'person_id', 'score', 'selected']
+        activitesExpectedColumns = ['id', 'plan_id', 'type', 'link', 'x', 'y', 'end_time', 'zoneId', 'max_dur', 'cemdapStopDuration_s']
+        legsExpectedColumns = ['id', 'plan_id', 'mode', 'dep_time']
+        routesExpectedColumns = ['id', 'leg_id', 'value', 'type', 'start_link', 'end_link', 'trav_time', 'distance', 'vehicleRefId']
+        
+        if filepath == 'plans_empty.xml.gz':
+            assert len(persons) == 3
+            assert len(plans) == 0
+            assert len(activities) == 0
+            assert len(legs) == 0
+            assert len(routes) == 0
+            np.testing.assert_array_equal(personsExpectedColumnsEmpty, persons.keys())
+            np.testing.assert_array_equal([], plans.keys())
+            np.testing.assert_array_equal([], activities.keys())
+            np.testing.assert_array_equal([], legs.keys())
+            np.testing.assert_array_equal([], routes.keys())
+
+        else:
+            assert len(persons) == 3
+            
+            if selectedPlansOnly:
+                assert len(plans) == 3
+            else:
+                assert len(plans) == 4
+            
+            assert len(activities) == 39
+            assert len(legs) == 35
+            assert len(routes) == 35
+            np.testing.assert_array_equal(personsExpectedColumnsFull, persons.keys())
+            np.testing.assert_array_equal(plansExpectedColumns, plans.keys())
+            np.testing.assert_array_equal(activitesExpectedColumns, activities.keys())
+            np.testing.assert_array_equal(legsExpectedColumns, legs.keys())
+            np.testing.assert_array_equal(routesExpectedColumns, routes.keys())


### PR DESCRIPTION
Returns dataframes with the following relations between them
Person : None
Plan : person_id
Activity : plan_id
Leg : plan_id
Route :leg_id
The column names of the dataframes are the same as the attribute names (<name:'value'> and <attribute> are parsed)