### PR TITLE
Added the plan inheritance record inspector

### DIFF
--- a/matsim/viz/main.py
+++ b/matsim/viz/main.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from argparse import ArgumentParser
+
+
+def start_piri(args):
+    from matsim.viz import piri
+    piri.app.run(debug=False)
+
+def main():
+    """ Main entry point. """
+
+    parser = ArgumentParser(prog='matsim-viz', description="MATSim viz util")
+    subparsers = parser.add_subparsers(title="Subcommands")
+
+    # Because the dash app can not easily be separated, the command lne parser is duplicated here
+    s1 = subparsers.add_parser("piri", help="Analyze the evolution of plans of a single agent or compare different agents side by side.")
+    s1.add_argument("inputfile", help="Full path to the file containing the plan inheritance records, e.g. path/to/matsim/output/planInheritanceRecords.csv.gz")
+
+    s1.set_defaults(func=start_piri)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/matsim/viz/piri.py
+++ b/matsim/viz/piri.py
@@ -12,6 +12,7 @@ import dash_cytoscape as cyto # graph plotting
 import dash_bootstrap_components as dbc # column formatting and stuff
 import argparse
 import io
+import sys
 
 # https://dash.plotly.com/cytoscape/layout
 # Load extra layouts - time consuming
@@ -21,15 +22,22 @@ cyto.load_extra_layouts()
 
 # Process command line arguments
 parser = argparse.ArgumentParser(prog="piri", description="Analyze the evolution of plans of a single agent or compare different agents side by side.")
+
+if "piri" in sys.argv:
+    parser.add_argument("cmd", help="Hidden argument to consume the 'piri' subcommand")
+
 parser.add_argument("inputfile", help="Full path to the file containing the plan inheritance records, e.g. path/to/matsim/output/planInheritanceRecords.csv.gz")
 args = parser.parse_args()
 
 # Read and PreProcess data
 pir = pd.read_csv(args.inputfile, sep='\t')
-pir['mutatedBy'] = pir['mutatedBy'].str.replace('_',' ')
-pir['iterationsSelected'] = pir['iterationsSelected'].str.replace('[','').str.replace(']','')
+pir['mutatedBy'] = pir['mutatedBy'].str.replace('_', ' ', regex=False)
+pir['iterationsSelected'] = pir['iterationsSelected'].str.replace('[', '', regex=False).str.replace(']', '',
+                                                                                                    regex=False)
 defaultagentId = pir['agentId'].unique()[0]
-pir['nodeClasses'] = pir.apply(lambda row: "initial" if row['ancestorId'] == "NONE" else "final" if row['iterationRemoved'] == -1 else "regular", axis=1)
+pir['nodeClasses'] = pir.apply(
+    lambda row: "initial" if row['ancestorId'] == "NONE" else "final" if row['iterationRemoved'] == -1 else "regular",
+    axis=1)
 
 # Initialize the app
 app = Dash(__name__,

--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,15 @@ setup(
         # m2cgen has problems with newer xgb, see this issue
         # https://github.com/BayesWitnesses/m2cgen/issues/581
         'scenariogen': ["sumolib", "traci", "lxml", "optax", "requests", "tqdm", "scikit-learn", "xgboost==1.7.1", "lightgbm",
-                        "sklearn-contrib-lightning", "numpy", "sympy", "m2cgen", "shapely", "optuna"]
+                        "sklearn-contrib-lightning", "numpy", "sympy", "m2cgen", "shapely", "optuna"],
+        'viz': ["dash", "plotly.express", "dash_cytoscape", "dash_bootstrap_components"]
     },
     tests_require=["assertpy", "pytest"],
     entry_points={
         'console_scripts': [
             'matsim-tools=matsim.cli.main:main',
-            'matsim-scenariogen=matsim.scenariogen:main'
+            'matsim-scenariogen=matsim.scenariogen:main',
+            'matsim-viz=matsim.viz:main',
         ]
     },
     long_description=README,


### PR DESCRIPTION
Initial release of the Plan Inheritance Record Inspector

The app is built on [Dash/Plotly](https://dash.plotly.com/). It allows to visually inspect the [plan inheritance records of a MATSim run](https://github.com/matsim-org/matsim-libs/pull/2831). Current status is:
- Two tabs with visualizations: The Single Agent Analysis and the Top N Overview.
- Added some patterns for interactions and styling that may facilitate the development of further analyses.
- Largest setup tested featured 640k plan inheritance records - 84k agents with max 4 plans for 160 iterations.

Single Trip Analysis
- Allows to inspects all plans of a single agent
- Choose or type in an agent id
- The table show all the plans of that agent - per default sorted by age
- The left plot links each plan with its ancestor. Each plan is shown once as a single node. The colored nodes represent the the initial plan and the plans of the final choice-set.
- The right plot follows the same lineage but features one node for each selected plan of each iteration. That is, a plan may be drawn more than once, if the plan had been selected in more than one iteration.
- Both plots allow to hover over a node which then highlights the corresponding plan in the table.

![image](https://github.com/matsim-vsp/matsim-python-tools/assets/1352652/5e3085c3-5a8f-437f-99ef-0ec007c8a570)

Top N Overview
- Allows to compare the lineage of the plans of the first n agent.
- For each iteration, the node represents the selected plan.
- Each selected plan is linked to its ancestor.

![image](https://github.com/matsim-vsp/matsim-python-tools/assets/1352652/9a5f45fa-5c87-4f7d-8f3e-5dd8bf40b609)
